### PR TITLE
Adds cancellationPreview call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.2.3
+  - 2.1.7
+  - 2.0.0
+  - 1.9.3
+  - jruby
+  - rbx-2

--- a/lib/pactas_itero/api/contracts.rb
+++ b/lib/pactas_itero/api/contracts.rb
@@ -20,6 +20,11 @@ module PactasItero
         options = options.camelize_keys
         get "api/v1/contracts/#{contract_id}", options
       end
+
+      def contract_cancellation_preview(contract_id, options = {})
+        options = options.camelize_keys
+        get "api/v1/contracts/#{contract_id}/cancellationPreview", options
+      end
     end
   end
 end

--- a/spec/fixtures/contract_cancellation_preview_response.json
+++ b/spec/fixtures/contract_cancellation_preview_response.json
@@ -1,0 +1,73 @@
+{
+  "ContractAfter": {
+    "Balance": 0,
+    "Currency": "EUR",
+    "CurrentPhase": {
+      "PlanId": "53567a9e1d8dd00df056564d",
+      "StartDate": "2015-10-15T09:02:21.2750000Z",
+      "Type": "Trial"
+    },
+    "CustomFields": {},
+    "CustomerId": "561f6b9d1d8dd21334f22cb0",
+    "CustomerName": "Example Corp.",
+    "EndDate": "2015-12-15T10:02:21.2750000Z",
+    "EscalationSuspended": false,
+    "Id": "561f6b9d1d8dd21334f22cb2",
+    "LifecycleStatus": "InTrial",
+    "NextBillingDate": "2015-11-15T10:02:21.2750000Z",
+    "PaymentBearer": {
+      "CardType": "visa",
+      "Country": "DE",
+      "ExpiryMonth": 12,
+      "ExpiryYear": 2017,
+      "Holder": "Marcellus Wallace",
+      "Last4": "1111",
+      "Type": "CreditCard"
+    },
+    "PaymentProvider": "Paymill",
+    "PaymentProviderSupportRefunds": true,
+    "Phases": [
+      {
+          "PlanId": "53567a9e1d8dd00df056564d",
+          "StartDate": "2015-10-15T09:02:21.2750000Z",
+          "Type": "Trial"
+      },
+      {
+          "PlanId": "53567a9e1d8dd00df056564d",
+          "PlanVariantId": "53567b431d8dd00df056564f",
+          "StartDate": "2015-11-15T10:02:21.2750000Z",
+          "Type": "Normal"
+      },
+      {
+          "StartDate": "2015-12-15T10:02:21.2750000Z",
+          "Type": "Inactive"
+      }
+    ],
+    "PlanGroupId": "53567a731d8dd00df056564a",
+    "PlanId": "53567a9e1d8dd00df056564d",
+    "RecurringPaymentsPaused": false,
+    "ReferenceCode": "RFDT-ZHXM",
+    "StartDate": "2015-10-15T09:02:21.2750000Z"
+  },
+  "EndDate": "2015-12-15T10:02:21.2750000Z",
+  "Invoice": {
+      "ContractId": "561f6b9d1d8dd21334f22cb2",
+      "CustomerId": "561f6b9d1d8dd21334f22cb0",
+      "ItemList": [],
+      "RecipientAddress": {
+          "City": "Example City",
+          "Country": "DE",
+          "HouseNumber": "42",
+          "PostalCode": "12345",
+          "Street": "Example Street"
+      },
+      "RecipientName": "Example Corp.",
+      "RecipientSubName": "Max Mustermann",
+      "ReverseCharge": false,
+      "TotalGross": 0,
+      "TotalNet": 0,
+      "TotalVat": 0,
+      "VatDescriptors": []
+  },
+  "NextPossibleCancellationDate": "2015-11-15T10:02:21.2750000Z"
+}

--- a/spec/pactas_itero/api/contracts_spec.rb
+++ b/spec/pactas_itero/api/contracts_spec.rb
@@ -57,6 +57,34 @@ describe PactasItero::Api::Customers do
     end
   end
 
+  describe ".contract_cancellation_preview" do
+    it "requests the correct resource" do
+      client = PactasItero::Client.new(bearer_token: "bt")
+      request = stub_get("/api/v1/contracts/some_contract_id/cancellationPreview").to_return(
+        body: fixture("contract_cancellation_preview_response.json"),
+        headers: { content_type: "application/json; charset=utf-8" }
+      )
+
+      client.contract_cancellation_preview("some_contract_id")
+
+      expect(request).to have_been_made
+    end
+
+    it 'returns the next possible cancellation date' do
+      client = PactasItero::Client.new(bearer_token: 'bt')
+      request = stub_get("/api/v1/contracts/some_contract_id/cancellationPreview").to_return(
+        body: fixture("contract_cancellation_preview_response.json"),
+        headers: { content_type: "application/json; charset=utf-8" }
+      )
+
+      contract_cancellation_preview = client.contract_cancellation_preview("some_contract_id")
+
+      expect(
+        contract_cancellation_preview.next_possible_cancellation_date
+      ).to eq "2015-11-15T10:02:21.2750000Z"
+    end
+  end
+
   describe '.update_contract' do
     it 'requests the correct resource' do
       client = PactasItero::Client.new(bearer_token: 'bt')


### PR DESCRIPTION
Adds method contract_cancellation_preview
implementing the cancellationPreview call.

More details can be found at http://developer.pactas.com/Docs/Recipes
in the Section "Terminate a Contract (with notice)"